### PR TITLE
Fix a static analysis failure: error 6386: Buffer overrun while writing to 'result':  the writable size is 'sizeof(size_t)*n_delims' bytes, but '16' bytes might be written.

### DIFF
--- a/src/string_token.c
+++ b/src/string_token.c
@@ -43,7 +43,7 @@ static size_t* get_delimiters_lengths(const char** delimiters, size_t n_delims)
             }
             else
             {
-                result[i] = strlen(delimiters[i]);
+                *(result + i) = strlen(delimiters[i]);
             }
         }
     }


### PR DESCRIPTION
Fix a static analysis failure: external\azure-c-shared-utility\src\string_token.c(46,26): error 6386:: Buffer overrun while writing to 'result':  the writable size is 'sizeof(size_t)*n_delims' bytes, but '16' bytes might be written.
I think the original code has no problem, it's just due to the analysis rule is not smart enough, use another equivalent expression to make it pass