### PR TITLE
Update HTTP API to support non-secure HTTP protocol & customized port

### DIFF
--- a/adapters/httpapi_compact.c
+++ b/adapters/httpapi_compact.c
@@ -37,9 +37,15 @@
 /*Codes_SRS_HTTPAPI_COMPACT_21_079: [ The HTTPAPI_ExecuteRequest shall wait, at least, 20 seconds to send a buffer using the SSL connection. ]*/
 #define MAX_SEND_RETRY   200
 /*Codes_SRS_HTTPAPI_COMPACT_21_081: [ The HTTPAPI_ExecuteRequest shall try to read the message with the response up to 20 seconds. ]*/
-#define MAX_RECEIVE_RETRY   200
-/*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_ExecuteRequest shall wait, at least, 100 milliseconds between retries. ]*/
-#define RETRY_INTERVAL_IN_MICROSECONDS  100
+#define MAX_RECEIVE_RETRY   2000
+/*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_ExecuteRequest shall wait, at least, 100 milliseconds between retries for the SSL open process. ]*/
+#define OPEN_RETRY_INTERVAL_IN_MILLISECONDS  100
+/*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_CloseConnection shall wait, at least, 100 milliseconds between retries for the SSL close process. ]*/
+#define CLOSE_RETRY_INTERVAL_IN_MILLISECONDS  100
+/*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_ExecuteRequest shall wait, at least, 100 milliseconds between retries to send a buffer using the SSL connection. ]*/
+#define SEND_RETRY_INTERVAL_IN_MILLISECONDS  100
+/*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_ExecuteRequest shall wait, at least, 10 milliseconds between retries to read the message with the response. ]*/
+#define RECEIVE_RETRY_INTERVAL_IN_MILLISECONDS  10
 
 DEFINE_ENUM_STRINGS(HTTPAPI_RESULT, HTTPAPI_RESULT_VALUES)
 
@@ -367,7 +373,7 @@ void HTTPAPI_CloseConnection(HTTP_HANDLE handle)
                     {
                         LogInfo("Waiting for TLS close connection");
                         /*Codes_SRS_HTTPAPI_COMPACT_21_086: [ The HTTPAPI_CloseConnection shall wait, at least, 100 milliseconds between retries. ]*/
-                        ThreadAPI_Sleep(RETRY_INTERVAL_IN_MICROSECONDS);
+                        ThreadAPI_Sleep(CLOSE_RETRY_INTERVAL_IN_MILLISECONDS);
                     }
                 }
             }
@@ -557,7 +563,7 @@ static int conn_receive(HTTP_HANDLE_DATA* http_instance, char* buffer, int count
             }
 
             /*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_ExecuteRequest shall wait, at least, 100 milliseconds between retries. ]*/
-            ThreadAPI_Sleep(RETRY_INTERVAL_IN_MICROSECONDS);
+            ThreadAPI_Sleep(RECEIVE_RETRY_INTERVAL_IN_MILLISECONDS);
         }
     }
 
@@ -652,7 +658,7 @@ static int readLine(HTTP_HANDLE_DATA* http_instance, char* buf, const size_t max
                 if ((countRetry--) > 0)
                 {
                     /*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_ExecuteRequest shall wait, at least, 100 milliseconds between retries. ]*/
-                    ThreadAPI_Sleep(RETRY_INTERVAL_IN_MICROSECONDS);
+                    ThreadAPI_Sleep(RECEIVE_RETRY_INTERVAL_IN_MILLISECONDS);
                 }
                 else
                 {
@@ -740,7 +746,7 @@ static int skipN(HTTP_HANDLE_DATA* http_instance, size_t n)
                     if ((countRetry--) > 0)
                     {
                         /*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_ExecuteRequest shall wait, at least, 100 milliseconds between retries. ]*/
-                        ThreadAPI_Sleep(RETRY_INTERVAL_IN_MICROSECONDS);
+                        ThreadAPI_Sleep(RECEIVE_RETRY_INTERVAL_IN_MILLISECONDS);
                     }
                     else
                     {
@@ -833,7 +839,7 @@ static HTTPAPI_RESULT OpenXIOConnection(HTTP_HANDLE_DATA* http_instance)
                     else
                     {
                         /*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_ExecuteRequest shall wait, at least, 100 milliseconds between retries. ]*/
-                        ThreadAPI_Sleep(RETRY_INTERVAL_IN_MICROSECONDS);
+                        ThreadAPI_Sleep(OPEN_RETRY_INTERVAL_IN_MILLISECONDS);
                     }
                 }
             }
@@ -884,7 +890,7 @@ static HTTPAPI_RESULT conn_send_all(HTTP_HANDLE_DATA* http_instance, const unsig
             else
             {
                 /*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_ExecuteRequest shall wait, at least, 100 milliseconds between retries. ]*/
-                ThreadAPI_Sleep(RETRY_INTERVAL_IN_MICROSECONDS);
+                ThreadAPI_Sleep(SEND_RETRY_INTERVAL_IN_MILLISECONDS);
             }
         }
     }

--- a/adapters/httpapi_compact.c
+++ b/adapters/httpapi_compact.c
@@ -31,7 +31,7 @@
 #define TEMP_BUFFER_SIZE 1024
 
 /*Codes_SRS_HTTPAPI_COMPACT_21_077: [ The HTTPAPI_ExecuteRequest shall wait, at least, 10 seconds for the SSL open process. ]*/
-#define MAX_OPEN_RETRY   100
+#define MAX_OPEN_RETRY   1000
 /*Codes_SRS_HTTPAPI_COMPACT_21_084: [ The HTTPAPI_CloseConnection shall wait, at least, 10 seconds for the SSL close process. ]*/
 #define MAX_CLOSE_RETRY   100
 /*Codes_SRS_HTTPAPI_COMPACT_21_079: [ The HTTPAPI_ExecuteRequest shall wait, at least, 20 seconds to send a buffer using the SSL connection. ]*/
@@ -39,7 +39,7 @@
 /*Codes_SRS_HTTPAPI_COMPACT_21_081: [ The HTTPAPI_ExecuteRequest shall try to read the message with the response up to 20 seconds. ]*/
 #define MAX_RECEIVE_RETRY   2000
 /*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_ExecuteRequest shall wait, at least, 100 milliseconds between retries for the SSL open process. ]*/
-#define OPEN_RETRY_INTERVAL_IN_MILLISECONDS  100
+#define OPEN_RETRY_INTERVAL_IN_MILLISECONDS  10
 /*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_CloseConnection shall wait, at least, 100 milliseconds between retries for the SSL close process. ]*/
 #define CLOSE_RETRY_INTERVAL_IN_MILLISECONDS  100
 /*Codes_SRS_HTTPAPI_COMPACT_21_083: [ The HTTPAPI_ExecuteRequest shall wait, at least, 100 milliseconds between retries to send a buffer using the SSL connection. ]*/

--- a/inc/azure_c_shared_utility/httpapi.h
+++ b/inc/azure_c_shared_utility/httpapi.h
@@ -103,10 +103,14 @@ MOCKABLE_FUNCTION(, void, HTTPAPI_Deinit);
 MOCKABLE_FUNCTION(, HTTP_HANDLE, HTTPAPI_CreateConnection, const char*, hostName);
 
 /**
- * @brief	Creates an HTTPS connection to the host specified by the @p
- * 			hostName parameter, with proxy
+ * @brief	Creates an HTTP/HTTPS connection to the host specified by the @p
+ * 			hostName, port, secure, and proxy parameters
  *
  * @param	hostName	Name of the host.
+ *
+ * @param	port		The port number.
+ *
+ * @param	secure		Whether the connect is secure(https).
  *
  * @param	proxyHost	Host name of the proxy.
  *
@@ -125,8 +129,10 @@ MOCKABLE_FUNCTION(, HTTP_HANDLE, HTTPAPI_CreateConnection, const char*, hostName
  * @return	A @c HTTP_HANDLE to the newly created connection or @c NULL in
  * 			case an error occurs.
  */
-MOCKABLE_FUNCTION(, HTTP_HANDLE, HTTPAPI_CreateConnection_With_Proxy, const char*, hostName, const char*, proxyHost,
-                                          int, proxyPort, const char*, proxyUsername, const char*, proxyPassword);
+MOCKABLE_FUNCTION(, HTTP_HANDLE, HTTPAPI_CreateConnection_Advanced, const char*, hostName,
+                                          int, port, bool, secure,
+                                          const char*, proxyHost, int, proxyPort, const char*,
+                                          proxyUsername, const char*, proxyPassword);
 
 /**
  * @brief	Closes a connection created with ::HTTPAPI_CreateConnection.


### PR DESCRIPTION
Update HTTP API to support non-secure HTTP protocol & customized port number, per requirement of on-prem TTS container:
https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-container-howto#query-the-containers-prediction-endpoint
