### PR TITLE
Changes for openssl on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ if(${use_openssl})
 
     find_package(OpenSSL REQUIRED)
     include_directories(${OPENSSL_INCLUDE_DIR})
-    message(status "openssl found at ${OPENSSL_INCLUDE_DIR}, libs at ${OPENSSL_LIBRARIES}")
+    message(STATUS "openssl headers found at ${OPENSSL_INCLUDE_DIR}, libs at ${OPENSSL_LIBRARIES}")
 endif()
 
 if(${use_applessl})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ if(${use_openssl})
 
     find_package(OpenSSL REQUIRED)
     include_directories(${OPENSSL_INCLUDE_DIR})
+    message(status "openssl found at ${OPENSSL_INCLUDE_DIR}, libs at ${OPENSSL_LIBRARIES}")
 endif()
 
 if(${use_applessl})

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -629,7 +629,6 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
 
                 sprintf(portString, "%u", socket_io_instance->port);
                 int err = getaddrinfo(socket_io_instance->hostname, portString, &addrHint, &addrInfo);
-                LogInfo("%s: Connecting to %s:%s -> %d.", __FUNCTION__, socket_io_instance->hostname, portString, err);
                 if (err != 0)
                 {
                     LogError("Failure: getaddrinfo failure %d.", err);

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -629,6 +629,7 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
 
                 sprintf(portString, "%u", socket_io_instance->port);
                 int err = getaddrinfo(socket_io_instance->hostname, portString, &addrHint, &addrInfo);
+                LogInfo("%s: Connecting to %s:%s -> %d.", __FUNCTION__, socket_io_instance->hostname, portString, err);
                 if (err != 0)
                 {
                     LogError("Failure: getaddrinfo failure %d.", err);

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -959,7 +959,7 @@ static int load_cert_crl_http(
         BIO_flush(bioPlain);
 
         char* realmBase64;
-        int length = BIO_get_mem_data(bioBase64, &realmBase64);
+        long length = BIO_get_mem_data(bioBase64, &realmBase64);
 
         sprintf_s(authData, sizeof(authData), "Basic %.*s", length, realmBase64);
 
@@ -1824,7 +1824,7 @@ static int setup_crl_check(TLS_IO_INSTANCE* tls_io_instance)
 #if USE_OPENSSL_1_1_0_OR_UP
     int flags = X509_VERIFY_PARAM_get_flags(X509_STORE_get0_param(store));
 #else
-    int flags = X509_VERIFY_PARAM_get_flags(store->param);
+    long flags = X509_VERIFY_PARAM_get_flags(store->param);
 #endif
     if (flags & X509_V_FLAG_CRL_CHECK)
     {

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -734,7 +734,6 @@ static void on_underlying_io_close_complete(void* context)
         break;
 
     case TLSIO_STATE_CLOSING:
-        LogInfo("Closing tlsio instance complete.");
         tls_io_instance->tlsio_state = TLSIO_STATE_NOT_OPEN;
 
         if (tls_io_instance->on_io_close_complete != NULL)
@@ -2343,8 +2342,6 @@ int tlsio_openssl_close(CONCRETE_IO_HANDLE tls_io, ON_IO_CLOSE_COMPLETE on_io_cl
         {
             // Attempt a graceful shutdown
             /* Codes_SRS_TLSIO_30_056: [ On success the adapter shall enter TLSIO_STATE_EX_CLOSING. ]*/
-            LogInfo("Closing tlsio instance...");
-
             tls_io_instance->tlsio_state = TLSIO_STATE_CLOSING;
             tls_io_instance->on_io_close_complete = on_io_close_complete;
             tls_io_instance->on_io_close_complete_context = callback_context;
@@ -2352,7 +2349,6 @@ int tlsio_openssl_close(CONCRETE_IO_HANDLE tls_io, ON_IO_CLOSE_COMPLETE on_io_cl
             // transition into TLSIO_STATE_NOT_OPEN
             if (xio_close(tls_io_instance->underlying_io, on_underlying_io_close_complete, tls_io_instance) != 0)
             {
-                LogInfo("Closed tlsio instance.");
                 close_openssl_instance(tls_io_instance);
                 tls_io_instance->tlsio_state = TLSIO_STATE_NOT_OPEN;
             }

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -2107,7 +2107,9 @@ void tlsio_openssl_deinit(void)
 
     openssl_dynamic_locks_uninstall();
     openssl_static_locks_uninstall();
+#ifndef __APPLE__
     FIPS_mode_set(0);
+#endif
     CRYPTO_set_locking_callback(NULL);
     CRYPTO_set_id_callback(NULL); // TODO already deprecated in 1.0.0 ?
     ERR_free_strings();

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -734,6 +734,7 @@ static void on_underlying_io_close_complete(void* context)
         break;
 
     case TLSIO_STATE_CLOSING:
+        LogInfo("Closing tlsio instance complete.");
         tls_io_instance->tlsio_state = TLSIO_STATE_NOT_OPEN;
 
         if (tls_io_instance->on_io_close_complete != NULL)
@@ -2335,6 +2336,8 @@ int tlsio_openssl_close(CONCRETE_IO_HANDLE tls_io, ON_IO_CLOSE_COMPLETE on_io_cl
         {
             // Attempt a graceful shutdown
             /* Codes_SRS_TLSIO_30_056: [ On success the adapter shall enter TLSIO_STATE_EX_CLOSING. ]*/
+            LogInfo("Closing tlsio instance...");
+
             tls_io_instance->tlsio_state = TLSIO_STATE_CLOSING;
             tls_io_instance->on_io_close_complete = on_io_close_complete;
             tls_io_instance->on_io_close_complete_context = callback_context;
@@ -2342,6 +2345,7 @@ int tlsio_openssl_close(CONCRETE_IO_HANDLE tls_io, ON_IO_CLOSE_COMPLETE on_io_cl
             // transition into TLSIO_STATE_NOT_OPEN
             if (xio_close(tls_io_instance->underlying_io, on_underlying_io_close_complete, tls_io_instance) != 0)
             {
+                LogInfo("Closed tlsio instance.");
                 close_openssl_instance(tls_io_instance);
                 tls_io_instance->tlsio_state = TLSIO_STATE_NOT_OPEN;
             }
@@ -2352,6 +2356,7 @@ int tlsio_openssl_close(CONCRETE_IO_HANDLE tls_io, ON_IO_CLOSE_COMPLETE on_io_cl
             /* Codes_SRS_TLSIO_30_056: [ On success the adapter shall enter TLSIO_STATE_EX_CLOSING. ]*/
             /* Codes_SRS_TLSIO_30_051: [ On success, if the underlying TLS does not support asynchronous closing or if the adapter is not in TLSIO_STATE_EXT_OPEN, then the adapter shall enter TLSIO_STATE_EXT_CLOSED immediately after entering TLSIO_STATE_EXT_CLOSING. ]*/
             // Current implementations of xio_close will fail if not in the open state, but we don't care
+            LogError("FORCE-Closing tlsio instance.");
             (void)xio_close(tls_io_instance->underlying_io, NULL, NULL);
             close_openssl_instance(tls_io_instance);
             tls_io_instance->tlsio_state = TLSIO_STATE_NOT_OPEN;

--- a/src/http_proxy_io.c
+++ b/src/http_proxy_io.c
@@ -184,6 +184,7 @@ static CONCRETE_IO_HANDLE http_proxy_io_create(void* io_create_parameters)
                                     {
                                         result->port = http_proxy_io_config->port;
                                         result->proxy_port = http_proxy_io_config->proxy_port;
+                                        LogInfo("%s: Setting up proxy with host:port %s:%d", __FUNCTION__, http_proxy_io_config->proxy_hostname, http_proxy_io_config->proxy_port);
                                         result->receive_buffer = NULL;
                                         result->receive_buffer_size = 0;
                                         result->http_proxy_io_state = HTTP_PROXY_IO_STATE_CLOSED;


### PR DESCRIPTION
- allow to link against openssl 1.1 from homebrew
- fix a warning about writing to a closed socket
- fix a few Xcode warnings
- more logging about connection status