### PR TITLE
socketio: fix discarded messages bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,11 @@ if(UNIX) #LINUX OR APPLE
     )
 endif()
 
+if(${use_openssl})
+    set(source_h_files ${source_h_files}
+        ./adapters/shim_openssl.h
+    )
+endif()
 if(${use_wsio})
     set(source_h_files ${source_h_files}
         ./inc/azure_c_shared_utility/wsio.h

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -826,22 +826,20 @@ int socketio_send(CONCRETE_IO_HANDLE socket_io, const void* buffer, size_t size,
                 ssize_t send_result = send(socket_io_instance->socket, buffer, size, 0);
                 if (send_result != size)
                 {
-                    if (send_result == INVALID_SOCKET)
+                    if (send_result == INVALID_SOCKET && errno != EAGAIN)
                     {
-                        if (errno == EAGAIN) /*send says "come back later" with EAGAIN - likely the socket buffer cannot accept more data*/
-                        {
-                            /*do nothing*/
-                            result = 0;
-                        }
-                        else
-                        {
-                            LogError("Failure: sending socket failed. errno=%d (%s).", errno, strerror(errno));
-                            result = __FAILURE__;
-                        }
+                        LogError("Failure: sending socket failed. errno=%d (%s).", errno, strerror(errno));
+                        result = __FAILURE__;
                     }
                     else
                     {
-                        /* queue data */
+                        if (send_result == INVALID_SOCKET && errno == EAGAIN) /*send says "come back later" with EAGAIN - likely the socket buffer cannot accept more data*/
+                        {
+                            // put the full message in the queue
+                            send_result = 0;
+                        }
+
+                        /* queue remaining data */
                         if (add_pending_io(socket_io_instance, buffer + send_result, size - send_result, on_send_complete, callback_context) != 0)
                         {
                             LogError("Failure: add_pending_io failed.");

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -1821,7 +1821,7 @@ static int setup_crl_check(TLS_IO_INSTANCE* tls_io_instance)
     store = SSL_CTX_get_cert_store(tls_io_instance->ssl_context);
 
 #if USE_OPENSSL_1_1_0_OR_UP
-    int flags = X509_VERIFY_PARAM_get_flags(X509_STORE_get0_param(store));
+    long flags = X509_VERIFY_PARAM_get_flags(X509_STORE_get0_param(store));
 #else
     long flags = X509_VERIFY_PARAM_get_flags(store->param);
 #endif

--- a/adapters/x509_openssl.c
+++ b/adapters/x509_openssl.c
@@ -7,12 +7,6 @@
 #include "azure_c_shared_utility/xlogging.h"
 #include "azure_c_shared_utility/const_defines.h"
 
-#ifdef __APPLE__
-    #ifndef EVP_PKEY_id
-        #define EVP_PKEY_id(evp_key) evp_key->type
-    #endif // EVP_PKEY_id
-#endif // __APPLE__
-
 static void log_ERR_get_error(const char* message)
 {
     char buf[128];


### PR DESCRIPTION
Fix a bug where messages that can't be sent on first try because the socket returns EAGAIN are discarded.

Also some Mac-specific minor changes, and slightly better logging of Openssl errors.