### PR TITLE
open ssl in TLSv1.2 protocol by detault

### DIFF
--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -1943,23 +1943,23 @@ static int create_openssl_instance(TLS_IO_INSTANCE* tlsInstance)
 #if !USE_OPENSSL_1_1_0_OR_UP
     if (tlsInstance->tls_version == OPTION_TLS_VERSION_1_2)
     {
-        LogInfo("create_openssl_instance by TLSv1_2_method");
+        LogInfo("create_openssl_instance by TLSv1_2_method.");
         method = TLSv1_2_method();
     }
     else if (tlsInstance->tls_version == OPTION_TLS_VERSION_1_1)
     {
-        LogInfo("create_openssl_instance by TLSv1_1_method");
+        LogInfo("create_openssl_instance by TLSv1_1_method.");
         method = TLSv1_1_method();
     }
     else
     {
-        LogInfo("create_openssl_instance by TLSv1_2_method");
+        LogInfo("create_openssl_instance by TLSv1_2_method by default.");
         method = TLSv1_2_method();
     }
 #else
     {
         // Note: TLS_method() uses highest negotiable.
-        LogInfo("create_openssl_instance by TLS_method");
+        LogInfo("create_openssl_instance by TLS_method.");
         method = TLS_method();
     }
 #endif

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -1943,19 +1943,23 @@ static int create_openssl_instance(TLS_IO_INSTANCE* tlsInstance)
 #if !USE_OPENSSL_1_1_0_OR_UP
     if (tlsInstance->tls_version == OPTION_TLS_VERSION_1_2)
     {
+        LogInfo("create_openssl_instance by TLSv1_2_method");
         method = TLSv1_2_method();
     }
     else if (tlsInstance->tls_version == OPTION_TLS_VERSION_1_1)
     {
+        LogInfo("create_openssl_instance by TLSv1_1_method");
         method = TLSv1_1_method();
     }
     else
     {
-        method = TLSv1_method();
+        LogInfo("create_openssl_instance by TLSv1_2_method");
+        method = TLSv1_2_method();
     }
 #else
     {
         // Note: TLS_method() uses highest negotiable.
+        LogInfo("create_openssl_instance by TLS_method");
         method = TLS_method();
     }
 #endif


### PR DESCRIPTION
I am running into an issue for sending a http request after a recognition session on Linux. Under Linux, we are using openssl 1.0.2. When carbon creates a websocket correction in transport.cpp, it ensures it first create a socket and then set the option of using TLSv1.2 protocol and then open the connection. When the recognition session is over, I am sending a http request. The httpapi_campact.c creates and opens the connection in one function, HTTPAPI_CreateConnection_Advanced. This gives users no chance to set option of TSLv1.2. So, openssl starts a TLSv1.1 and failed in handshaking. 

The existing TTS REST unit tests work due to that fact that they do not recognition session. So, they always start in TSL1.1.

This problem is on Linux only since Carbon uses schannel instead of openssl under Windows.

This is not a problem when using openssl 1.1, where tlsio_openssl.c always open in TLS_method.

We can't upgrade to openssl 1.1 for now since the only openssl for UWP winrt is only 1.0.2.
