### PR TITLE
Use berkly sockets for non-TLS traffic on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if (MACOSX)
     else()
         # MACOSX only has native tls and open ssl, so this must be the native apple tls
         set(use_applessl ON)
-        set(use_socketio OFF)
+        set(use_socketio ON)
     endif()
 endif()
 

--- a/pal/ios-osx/tlsio_appleios.c
+++ b/pal/ios-osx/tlsio_appleios.c
@@ -842,8 +842,3 @@ const IO_INTERFACE_DESCRIPTION* tlsio_appleios_get_interface_description(void)
     return &tlsio_appleios_interface_description;
 }
 
-const IO_INTERFACE_DESCRIPTION* socketio_get_interface_description(void)
-{
-    return NULL;
-}
-


### PR DESCRIPTION
Currently the behavior is to fail non-SSL connections on Mac, which causes problems when running against a local container.

https://github.com/Azure-Samples/cognitive-services-speech-sdk/issues/310