### PR TITLE
Handle custom headers on uws_client UPGRADE request

### DIFF
--- a/devdoc/uws_client_requirements.md
+++ b/devdoc/uws_client_requirements.md
@@ -84,7 +84,7 @@ MOCKABLE_FUNCTION(, int, uws_client_close_async, UWS_CLIENT_HANDLE, uws_client, 
 MOCKABLE_FUNCTION(, int, uws_client_close_handshake_async, UWS_CLIENT_HANDLE, uws_client, uint16_t, close_code, const char*, close_reason, ON_WS_CLOSE_COMPLETE, on_ws_close_complete, void*, on_ws_close_complete_context);
 MOCKABLE_FUNCTION(, int, uws_client_send_frame_async, UWS_CLIENT_HANDLE, uws_client, unsigned char, frame_type, const unsigned char*, buffer, size_t, size, bool, is_final, ON_WS_SEND_FRAME_COMPLETE, on_ws_send_frame_complete, void*, callback_context);
 MOCKABLE_FUNCTION(, void, uws_client_dowork, UWS_CLIENT_HANDLE, uws_client);
-
+MOCKABLE_FUNCTION(, int, uws_client_set_request_header, UWS_CLIENT_HANDLE, uws_client, const char*, name, const char*, value);
 MOCKABLE_FUNCTION(, int, uws_client_set_option, UWS_CLIENT_HANDLE, uws_client, const char*, option_name, const void*, value);
 MOCKABLE_FUNCTION(, OPTIONHANDLER_HANDLE, uws_client_retrieve_options, UWS_CLIENT_HANDLE, uws_client);
 ```
@@ -253,6 +253,19 @@ XX**SRS_UWS_CLIENT_01_059: [** If the `uws_client` argument is NULL, `uws_client
 XX**SRS_UWS_CLIENT_01_060: [** If the IO is not yet open, `uws_client_dowork` shall do nothing. **]**  
 XX**SRS_UWS_CLIENT_01_430: [** `uws_client_dowork` shall call `xio_dowork` with the IO handle argument set to the underlying IO created in `uws_client_create`. **]**  
 
+
+### uws_client_set_request_header
+
+```c
+int uws_client_set_request_header(UWS_CLIENT_HANDLE uws_client, const char* name, const char* value);
+```
+
+XX**SRS_UWS_CLIENT_09_002: [** If any of the arguments `uws_client` or `name` or `value` is NULL `uws_client_set_request_header` shall fail and return a non-zero value. **]**  
+XX**SRS_UWS_CLIENT_09_003: [** A copy of `name` and `value` shall be stored for later sending in the request message. **]**  
+XX**SRS_UWS_CLIENT_09_004: [** If `name` or `value` fail to be stored the function shall fail and return a non-zero value. **]**  
+XX**SRS_UWS_CLIENT_09_005: [** If no failures occur the function shall return zero. **]**  
+
+
 ### uws_setoption
 
 ```c
@@ -315,6 +328,7 @@ XX**SRS_UWS_CLIENT_01_371: [** When `on_underlying_io_open_complete` is called w
 X**SRS_UWS_CLIENT_01_408: [** If constructing of the WebSocket upgrade request fails, uws shall report that the open failed by calling the `on_ws_open_complete` callback passed to `uws_client_open_async` with `WS_OPEN_ERROR_CONSTRUCTING_UPGRADE_REQUEST`. **]**  
 XX**SRS_UWS_CLIENT_01_497: [** The nonce needed for the upgrade request shall be Base64 encoded with `Base64_Encode_Bytes`. **]**  
 XX**SRS_UWS_CLIENT_01_498: [** If Base64 encoding the nonce for the upgrade request fails, then the uws client shall report that the open failed by calling the `on_ws_open_complete` callback passed to `uws_client_open_async` with `WS_OPEN_ERROR_BASE64_ENCODE_FAILED`. **]**  
+
 XX**SRS_UWS_CLIENT_01_406: [** If not enough memory can be allocated to construct the WebSocket upgrade request, uws shall report that the open failed by calling the `on_ws_open_complete` callback passed to `uws_client_open_async` with `WS_OPEN_ERROR_NOT_ENOUGH_MEMORY`. **]**  
 XX**SRS_UWS_CLIENT_01_372: [** Once prepared the WebSocket upgrade request shall be sent by calling `xio_send`. **]**  
 XX**SRS_UWS_CLIENT_01_373: [** If `xio_send` fails then uws shall report that the open failed by calling the `on_ws_open_complete` callback passed to `uws_client_open_async` with `WS_OPEN_ERROR_CANNOT_SEND_UPGRADE_REQUEST`. **]**  

--- a/inc/azure_c_shared_utility/uws_client.h
+++ b/inc/azure_c_shared_utility/uws_client.h
@@ -112,7 +112,7 @@ MOCKABLE_FUNCTION(, int, uws_client_close_async, UWS_CLIENT_HANDLE, uws_client, 
 MOCKABLE_FUNCTION(, int, uws_client_close_handshake_async, UWS_CLIENT_HANDLE, uws_client, uint16_t, close_code, const char*, close_reason, ON_WS_CLOSE_COMPLETE, on_ws_close_complete, void*, on_ws_close_complete_context);
 MOCKABLE_FUNCTION(, int, uws_client_send_frame_async, UWS_CLIENT_HANDLE, uws_client, unsigned char, frame_type, const unsigned char*, buffer, size_t, size, bool, is_final, ON_WS_SEND_FRAME_COMPLETE, on_ws_send_frame_complete, void*, callback_context);
 MOCKABLE_FUNCTION(, void, uws_client_dowork, UWS_CLIENT_HANDLE, uws_client);
-
+MOCKABLE_FUNCTION(, int, uws_client_set_request_header, UWS_CLIENT_HANDLE, uws_client, const char*, name, const char*, value);
 MOCKABLE_FUNCTION(, int, uws_client_set_option, UWS_CLIENT_HANDLE, uws_client, const char*, option_name, const void*, value);
 MOCKABLE_FUNCTION(, OPTIONHANDLER_HANDLE, uws_client_retrieve_options, UWS_CLIENT_HANDLE, uws_client);
 


### PR DESCRIPTION
This adds a way to explicitly set headers on the web socket upgrade requests removing the need for the hack using the protocol header.

Cherry picked from [28e6dda07a07b2daa934917153f3619c81ee7e14](https://github.com/Azure/azure-c-shared-utility/commit/28e6dda07a07b2daa934917153f3619c81ee7e14) in https://github.com/Azure/azure-c-shared-utility/