### PR TITLE
suppress PreFast warnings in CShared Lib code.

### DIFF
--- a/adapters/httpapi_compact.c
+++ b/adapters/httpapi_compact.c
@@ -1394,6 +1394,8 @@ HTTPAPI_RESULT HTTPAPI_ExecuteRequest_With_Streaming(HTTP_HANDLE handle, HTTPAPI
 /*Codes_SRS_HTTPAPI_COMPACT_21_058: [ The HTTPAPI_SetOption shall receive the option as a pair optionName/value. ]*/
 HTTPAPI_RESULT HTTPAPI_SetOption(HTTP_HANDLE handle, const char* optionName, const void* value)
 {
+#pragma warning(push)
+#pragma warning(disable:26451)
     HTTPAPI_RESULT result;
     HTTP_HANDLE_DATA* http_instance = (HTTP_HANDLE_DATA*)handle;
 
@@ -1462,7 +1464,6 @@ HTTPAPI_RESULT HTTPAPI_SetOption(HTTP_HANDLE handle, const char* optionName, con
         {
             free(http_instance->x509ClientPrivateKey);
         }
-
         len = (int)strlen((char*)value);
         http_instance->x509ClientPrivateKey = (char*)malloc((len + 1) * sizeof(char));
         if (http_instance->x509ClientPrivateKey == NULL)
@@ -1493,6 +1494,7 @@ HTTPAPI_RESULT HTTPAPI_SetOption(HTTP_HANDLE handle, const char* optionName, con
         }
     }
     return result;
+#pragma warning(pop) // C26451
 }
 
 /*Codes_SRS_HTTPAPI_COMPACT_21_065: [ The HTTPAPI_CloneOption shall provide the means to clone the HTTP option. ]*/

--- a/adapters/tlsio_schannel.c
+++ b/adapters/tlsio_schannel.c
@@ -480,6 +480,8 @@ static int send_chunk(CONCRETE_IO_HANDLE tls_io, const void* buffer, size_t size
                     }
                     else
                     {
+#pragma warning(push)
+#pragma warning(disable:26451)
                         if (xio_send(tls_io_instance->socket_io, out_buffer, security_buffers[0].cbBuffer + security_buffers[1].cbBuffer + security_buffers[2].cbBuffer, on_send_complete, callback_context) != 0)
                         {
                             LogError("xio_send failed");
@@ -489,6 +491,7 @@ static int send_chunk(CONCRETE_IO_HANDLE tls_io, const void* buffer, size_t size
                         {
                             result = 0;
                         }
+#pragma warning(pop) // C26451
                     }
 
                     free(out_buffer);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -184,10 +184,13 @@ int BUFFER_append_build(BUFFER_HANDLE handle, const unsigned char* source, size_
             }
             else
             {
+#pragma warning(push)
+#pragma warning(disable:6387)
                 /* Codes_SRS_BUFFER_07_031: [ ... and copy the contents of source to handle->buffer. ] */
                 (void)memcpy(handle->buffer, source, size);
                 /* Codes_SRS_BUFFER_07_034: [ On success BUFFER_append_build shall return 0 ] */
                 result = 0;
+#pragma warning(pop) // C6387
             }
         }
         else

--- a/src/consolelogger.c
+++ b/src/consolelogger.c
@@ -13,6 +13,8 @@
 /*returns a string as if printed by vprintf*/
 static char* vprintf_alloc(const char* format, va_list va)
 {
+#pragma warning(push)
+#pragma warning(disable:26451)
     char* result;
     int neededSize = vsnprintf(NULL, 0, format, va);
     if (neededSize < 0)
@@ -35,6 +37,7 @@ static char* vprintf_alloc(const char* format, va_list va)
             }
         }
     }
+#pragma warning(pop) // C26451
     return result;
 }
 

--- a/src/crt_abstractions.c
+++ b/src/crt_abstractions.c
@@ -14,6 +14,8 @@
 #include "azure_c_shared_utility/optimize_size.h"
 #include "azure_c_shared_utility/crt_abstractions.h"
 
+#pragma warning(push)
+#pragma warning(disable:26451)
 // VS 2008 does not have INFINITY and all the nice goodies...
 #if defined (TIZENRT) || defined (WINCE)
 #define DEFINE_INFINITY 1
@@ -541,6 +543,7 @@ static FLOAT_STRING_TYPE splitFloatString(const char* nptr, char** endptr, int *
 
         if (result == FST_NUMBER)
         {
+
             /* Add ullInteger to ullFraction. */
             ullFraction += (ullInteger * (unsigned long long)(pow(10, (double)fractionSize)));
             (*fraction) = ((double)ullFraction / (pow(10.0f, (double)(fractionSize + integerSize - 1))));
@@ -549,7 +552,6 @@ static FLOAT_STRING_TYPE splitFloatString(const char* nptr, char** endptr, int *
             (*exponential) += integerSize - 1;
         }
     }
-
     return result;
 }
 
@@ -820,3 +822,4 @@ int size_tToString(char* destination, size_t destinationSize, size_t value)
     }
     return result;
 }
+#pragma warning(pop) // C26451

--- a/src/http_proxy_io.c
+++ b/src/http_proxy_io.c
@@ -246,6 +246,8 @@ static void unchecked_on_send_complete(void* context, IO_SEND_RESULT send_result
 
 static void on_underlying_io_open_complete(void* context, IO_OPEN_RESULT_DETAILED open_result_detailed)
 {
+#pragma warning(push)
+#pragma warning(disable:26451)
     IO_OPEN_RESULT open_result = open_result_detailed.result;
     if (context == NULL)
     {
@@ -454,6 +456,7 @@ static void on_underlying_io_open_complete(void* context, IO_OPEN_RESULT_DETAILE
             break;
         }
     }
+#pragma warning(pop) // C26451
 }
 
 static void on_underlying_io_error(void* context)

--- a/src/sastoken.c
+++ b/src/sastoken.c
@@ -23,7 +23,10 @@ static double getExpiryValue(const char* expiryASCII)
     {
         if (expiryASCII[i] >= '0' && expiryASCII[i] <= '9')
         {
+#pragma warning(push)
+#pragma warning(disable:26451)
             value = value * 10 + (expiryASCII[i] - '0');
+#pragma warning(pop) // C26451
         }
         else
         {
@@ -152,7 +155,11 @@ bool SASToken_Validate(STRING_HANDLE sasToken)
             }
             else
             {
+#pragma warning(push)
+#pragma warning(disable:26451)
                 char* expiryASCII = (char*)malloc(seStop - seStart + 1);
+#pragma warning(pop) // C26451
+
                 /*Codes_SRS_SASTOKEN_25_031: [**If malloc fails during validation then SASToken_Validate shall return false.**]***/
                 if (expiryASCII == NULL)
                 {
@@ -161,8 +168,11 @@ bool SASToken_Validate(STRING_HANDLE sasToken)
                 else
                 {
                     double expiry;
+#pragma warning(push)
+#pragma warning(disable:26451)
                     // Add the Null terminator here
                     memset(expiryASCII, 0, seStop - seStart + 1);
+#pragma warning(pop) // C26451
                     for (i = seStart; i < seStop; i++)
                     {
                         // The se contains the expiration values, if a & token is encountered then 

--- a/src/singlylinkedlist.c
+++ b/src/singlylinkedlist.c
@@ -44,9 +44,12 @@ void singlylinkedlist_destroy(SINGLYLINKEDLIST_HANDLE list)
 
         while (list_instance->head != NULL)
         {
+#pragma warning(push)
+#pragma warning(disable:6001)
             LIST_ITEM_INSTANCE* current_item = list_instance->head;
             list_instance->head = (LIST_ITEM_INSTANCE*)current_item->next;
             free(current_item);
+#pragma warning(pop) // C6001
         }
 
         /* Codes_SRS_LIST_01_003: [singlylinkedlist_destroy shall free all resources associated with the list identified by the handle argument.] */

--- a/src/strings.c
+++ b/src/strings.c
@@ -152,11 +152,14 @@ STRING_HANDLE STRING_construct_sprintf(const char* format, ...)
             result = (STRING*)malloc(sizeof(STRING));
             if (result != NULL)
             {
+#pragma warning(push)
+#pragma warning(disable:26451)
                 result->s = (char*)malloc(length+1);
                 if (result->s != NULL)
                 {
                     va_start(arg_list, format);
                     if (vsnprintf(result->s, length+1, format, arg_list) < 0)
+#pragma warning(pop) // C26451
                     {
                         /* Codes_SRS_STRING_07_040: [If any error is encountered STRING_construct_sprintf shall return NULL.] */
                         free(result->s);

--- a/src/uws_client.c
+++ b/src/uws_client.c
@@ -557,7 +557,10 @@ void uws_client_destroy(UWS_CLIENT_HANDLE uws_client)
             /* Codes_SRS_UWS_CLIENT_01_437: [ `uws_client_destroy` shall free the protocols array allocated in `uws_client_create`. ]*/
             for (i = 0; i < uws_client->protocol_count; i++)
             {
+#pragma warning(push)
+#pragma warning(disable:6001)
                 free(uws_client->protocols[i].protocol);
+#pragma warning(pop) // C6001
             }
 
             free(uws_client->protocols);
@@ -845,7 +848,10 @@ static void on_underlying_io_open_complete(void* context, IO_OPEN_RESULT_DETAILE
                     }
                     else
                     {
+#pragma warning(push)
+#pragma warning(disable:26451)
                         upgrade_request = (char*)malloc(upgrade_request_length + 1);
+#pragma warning(pop) // C26451
                         if (upgrade_request == NULL)
                         {
                             /* Codes_SRS_UWS_CLIENT_01_406: [ If not enough memory can be allocated to construct the WebSocket upgrade request, uws shall report that the open failed by calling the `on_ws_open_complete` callback passed to `uws_client_open_async` with `WS_OPEN_ERROR_NOT_ENOUGH_MEMORY`. ]*/


### PR DESCRIPTION
I added PreFast SDL scans to the carbon build, and now it is flagging several warnings in the C Shared Lib code base.
Suppressing them for now, as they all seem to be false positives...