### PR TITLE
Code changes for making crl config for max size

### DIFF
--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -88,7 +88,7 @@ struct CRYPTO_dynlock_value
 
 static const char* const OPTION_UNDERLYING_IO_OPTIONS = "underlying_io_options";
 #define SSL_DO_HANDSHAKE_SUCCESS 1
-static int g_ssl_cert_max_size = 10;
+static int g_ssl_cert_max_size_in_mb = 10;
 
 /*this function will clone an option given by name and value*/
 static void* tlsio_openssl_CloneOption(const char* name, const void* value)
@@ -934,7 +934,7 @@ static int load_cert_crl_http(
         goto error;
     }
 
-    OCSP_set_max_response_length(rctx, 10 * 1024 * 1024);
+    OCSP_set_max_response_length(rctx, g_ssl_cert_max_size_in_mb * 1024 * 1024);
 
     if (!OCSP_REQ_CTX_http(rctx, "GET", isHostnameSet ? url : path))
     {
@@ -2710,7 +2710,7 @@ int tlsio_openssl_setoption(CONCRETE_IO_HANDLE tls_io, const char* optionName, c
                 result = 0;
             }
         }
-        else if (strcmp(OPTION_TRUSTED_CERT_MAX_SIZE, optionName) == 0)
+        else if (strcmp(OPTION_TRUSTED_CERT_MAX_SIZE_IN_MB, optionName) == 0)
         {
             if (tls_io_instance->ssl_context != NULL)
             {
@@ -2719,7 +2719,7 @@ int tlsio_openssl_setoption(CONCRETE_IO_HANDLE tls_io, const char* optionName, c
             }
             else
             {
-                g_ssl_cert_max_size = *(const int*)value;
+                g_ssl_cert_max_size_in_mb = *(const int*)value;
                 result = 0;
             }
         }

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -88,6 +88,7 @@ struct CRYPTO_dynlock_value
 
 static const char* const OPTION_UNDERLYING_IO_OPTIONS = "underlying_io_options";
 #define SSL_DO_HANDSHAKE_SUCCESS 1
+static int g_ssl_cert_max_size = 10;
 
 /*this function will clone an option given by name and value*/
 static void* tlsio_openssl_CloneOption(const char* name, const void* value)
@@ -2706,6 +2707,19 @@ int tlsio_openssl_setoption(CONCRETE_IO_HANDLE tls_io, const char* optionName, c
             else
             {
                 tls_io_instance->continue_on_crl_download_failure = *(const bool*)value;
+                result = 0;
+            }
+        }
+        else if (strcmp(OPTION_TRUSTED_CERT_MAX_SIZE, optionName) == 0)
+        {
+            if (tls_io_instance->ssl_context != NULL)
+            {
+                LogError("Unable to set the %s option after the TLS connection is established", optionName);
+                result = __FAILURE__;
+            }
+            else
+            {
+                g_ssl_cert_max_size = *(const int*)value;
                 result = 0;
             }
         }

--- a/inc/azure_c_shared_utility/shared_util_options.h
+++ b/inc/azure_c_shared_utility/shared_util_options.h
@@ -27,6 +27,7 @@ extern "C"
     static STATIC_VAR_UNUSED const char* const OPTION_DISABLE_CRL_CHECK = "DisableCrlCheck";
     static STATIC_VAR_UNUSED const char* const OPTION_CONTINUE_ON_CRL_DOWNLOAD_FAILURE = "ContinueOnCrlDownloadFailure";
     static STATIC_VAR_UNUSED const char* const OPTION_DISABLE_DEFAULT_VERIFY_PATHS = "DisableDefaultVerifyPath";
+    static STATIC_VAR_UNUSED const char* const OPTION_TRUSTED_CERT_MAX_SIZE = "TrustedCertMaxSize";
 
     static STATIC_VAR_UNUSED const char* const SU_OPTION_X509_CERT = "x509certificate";
     static STATIC_VAR_UNUSED const char* const SU_OPTION_X509_PRIVATE_KEY = "x509privatekey";

--- a/inc/azure_c_shared_utility/shared_util_options.h
+++ b/inc/azure_c_shared_utility/shared_util_options.h
@@ -27,7 +27,7 @@ extern "C"
     static STATIC_VAR_UNUSED const char* const OPTION_DISABLE_CRL_CHECK = "DisableCrlCheck";
     static STATIC_VAR_UNUSED const char* const OPTION_CONTINUE_ON_CRL_DOWNLOAD_FAILURE = "ContinueOnCrlDownloadFailure";
     static STATIC_VAR_UNUSED const char* const OPTION_DISABLE_DEFAULT_VERIFY_PATHS = "DisableDefaultVerifyPath";
-    static STATIC_VAR_UNUSED const char* const OPTION_TRUSTED_CERT_MAX_SIZE = "TrustedCertMaxSize";
+    static STATIC_VAR_UNUSED const char* const OPTION_TRUSTED_CERT_MAX_SIZE_IN_MB = "TrustedCertMaxSizeInMB";
 
     static STATIC_VAR_UNUSED const char* const SU_OPTION_X509_CERT = "x509certificate";
     static STATIC_VAR_UNUSED const char* const SU_OPTION_X509_PRIVATE_KEY = "x509privatekey";


### PR DESCRIPTION
Some customers who are downloading crl file of size bigger than 10mb, the azure c lib was not able to download the file. With this changes they can configure the size in mbs.