### PR TITLE
Set cmake policy to honor visibility properties for all targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@
 
 cmake_minimum_required(VERSION 2.8.11)
 
+# Honor visibility properties for all target types
+cmake_policy(SET CMP0063 NEW)
+
 if (TARGET aziotsharedutil)
     RETURN()
 endif()


### PR DESCRIPTION
Set cmake policy to honor visibility properties for all targets (aziotsharedutil in particular).

This fixes the following warning in Speech SDK builds
```
   CMake Warning (dev) at external/azure-c-shared-utility/CMakeLists.txt:358 (add_library):
      Policy CMP0063 is not set: Honor visibility properties for all target
      types.  Run "cmake --help-policy CMP0063" for policy details.  Use the
      cmake_policy command to set the policy and suppress this warning.

      Target "aziotsharedutil" of type "STATIC_LIBRARY" has the following
      visibility properties set for C:

        C_VISIBILITY_PRESET

      For compatibility CMake is not honoring them for this target.
```
as well as prevents Speech SDK shared Linux libraries from exporting symbols not related to Speech SDK API, which has caused conflicts when an app is linked with Speech SDK and some other Azure SDK that uses (original) azure-c-shared-utility.

Without this fix:
```
    $ nm -DC libMicrosoft.CognitiveServices.Speech.core.so | grep " T "
    00000000003dc923 T BUFFER_append
    00000000003dc2c2 T BUFFER_append_build
    00000000003dc1fc T BUFFER_build
    00000000003dcbc5 T BUFFER_clone
    00000000003dc53e T BUFFER_content
    00000000003dc0ad T BUFFER_create
    00000000003dc1da T BUFFER_delete
    00000000003dc5d3 T BUFFER_enlarge
    00000000003dcb25 T BUFFER_fill
    00000000003dcbb5 T BUFFER_length
    00000000003dc086 T BUFFER_new
    00000000003dc45a T BUFFER_pre_build
    00000000003dca10 T BUFFER_prepend
    00000000003dc6fd T BUFFER_shrink
    00000000003dc900 T BUFFER_size
    ...
```