### PR TITLE
Honor visibility properties for all target types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@
 
 cmake_minimum_required(VERSION 2.8.11)
 
+# Honor visibility properties for all target types
+cmake_policy(SET CMP0063 NEW)
+
 if (TARGET aziotsharedutil)
     RETURN()
 endif()

--- a/adapters/httpapi_compact.c
+++ b/adapters/httpapi_compact.c
@@ -1279,7 +1279,7 @@ HTTPAPI_RESULT HTTPAPI_ExecuteRequest_Internal(HTTP_HANDLE handle, HTTPAPI_REQUE
     BUFFER_HANDLE responseContent, ON_CHUNK_RECEIVED onChunkReceived, void* onChunkReceivedContext)
 {
     HTTPAPI_RESULT result = HTTPAPI_ERROR;
-    size_t  headersCount;
+    size_t  headersCount = 0;
     size_t  bodyLength = 0;
     bool    chunked = false;
     HTTP_HANDLE_DATA* http_instance = (HTTP_HANDLE_DATA*)handle;

--- a/src/httpheaders.c
+++ b/src/httpheaders.c
@@ -251,9 +251,9 @@ HTTP_HEADERS_RESULT HTTPHeaders_GetHeader(HTTP_HEADERS_HANDLE handle, size_t ind
     else
     {
         HTTP_HEADERS_HANDLE_DATA* handleData = (HTTP_HEADERS_HANDLE_DATA*)handle;
-        const char*const* keys;
-        const char*const* values;
-        size_t headerCount;
+        const char*const* keys = NULL;
+        const char*const* values = NULL;
+        size_t headerCount = 0;
         if (Map_GetInternals(handleData->headers, &keys, &values, &headerCount) != MAP_OK)
         {
             /*Codes_SRS_HTTP_HEADERS_99_034:[ The function shall return HTTP_HEADERS_ERROR when an internal error occurs]*/

--- a/src/uws_client.c
+++ b/src/uws_client.c
@@ -677,9 +677,9 @@ static void indicate_ws_error_and_close(UWS_CLIENT_INSTANCE* uws_client, WS_ERRO
 static char* get_request_headers(MAP_HANDLE headers)
 {
     char* result;
-    const char* const* keys;
-    const char* const* values;
-    size_t count;
+    const char* const* keys = NULL;
+    const char* const* values = NULL;
+    size_t count = 0;
 
     if (Map_GetInternals(headers, &keys, &values, &count) != MAP_OK)
     {


### PR DESCRIPTION
Set cmake policy CMP0063 to honor visibility properties for all target types, which prevents symbols in static aziotsharedutil library (BUFFER_append etc.) from appearing in shared objects' export table when they are linked with aziotsharedutil.

This change triggered some 'maybe-uninitialized' errors from variables without an initial value, which are fixed here as well.