### PR TITLE
removes old-style function declaration

### DIFF
--- a/src/gballoc.c
+++ b/src/gballoc.c
@@ -427,7 +427,7 @@ size_t gballoc_getAllocationCount(void)
     return result;
 }
 
-void gballoc_resetMetrics()
+void gballoc_resetMetrics(void)
 {
     /* Codes_SRS_GBALLOC_07_005: [ If gballoc was not initialized gballoc_reset Metrics shall do nothing.] */
     if (gballocState != GBALLOC_STATE_INIT)

--- a/src/gbnetwork.c
+++ b/src/gbnetwork.c
@@ -69,7 +69,7 @@ void gbnetwork_deinit(void)
     gbnetworkState = GBNETWORK_STATE_NOT_INIT;
 }
 
-void gbnetwork_resetMetrics()
+void gbnetwork_resetMetrics(void)
 {
     if (gbnetworkState != GBNETWORK_STATE_INIT)
     {
@@ -190,7 +190,7 @@ uint64_t gbnetwork_getNumSends(void)
     return result;
 }
 
-uint64_t gbnetwork_getBytesRecv()
+uint64_t gbnetwork_getBytesRecv(void)
 {
     uint64_t result;
 
@@ -212,7 +212,7 @@ uint64_t gbnetwork_getBytesRecv()
     return result;
 }
 
-uint64_t gbnetwork_getNumRecv()
+uint64_t gbnetwork_getNumRecv(void)
 {
     uint64_t result;
 


### PR DESCRIPTION
The old-style syntax is obsolete and in some modern build system or pedantic build flags build breaks will be produced.