### PR TITLE
Fix for SDL warning in consolelogger.c

### DIFF
--- a/src/consolelogger.c
+++ b/src/consolelogger.c
@@ -15,10 +15,10 @@ static char* vprintf_alloc(const char* format, va_list va)
 {
 #pragma warning(push)
 #pragma warning(disable:26451)
-#pragma warning(disable:6386)
+//#pragma warning(disable:6386)
     char* result;
     int neededSize = vsnprintf(NULL, 0, format, va);
-    if (neededSize < 0)
+    if (neededSize <= 0)
     {
         result = NULL;
     }

--- a/src/consolelogger.c
+++ b/src/consolelogger.c
@@ -37,7 +37,7 @@ static char* vprintf_alloc(const char* format, va_list va)
             }
         }
     }
-#pragma warning(pop) // C26451 C6386
+#pragma warning(pop) // C26451
     return result;
 }
 

--- a/src/consolelogger.c
+++ b/src/consolelogger.c
@@ -14,7 +14,7 @@
 static char* vprintf_alloc(const char* format, va_list va)
 {
 #pragma warning(push)
-#pragma warning(disable:26451)
+#pragma warning(disable:26451 6386)
     char* result;
     int neededSize = vsnprintf(NULL, 0, format, va);
     if (neededSize < 0)
@@ -37,7 +37,7 @@ static char* vprintf_alloc(const char* format, va_list va)
             }
         }
     }
-#pragma warning(pop) // C26451
+#pragma warning(pop) // C26451 C6386
     return result;
 }
 

--- a/src/consolelogger.c
+++ b/src/consolelogger.c
@@ -15,7 +15,6 @@ static char* vprintf_alloc(const char* format, va_list va)
 {
 #pragma warning(push)
 #pragma warning(disable:26451)
-//#pragma warning(disable:6386)
     char* result;
     int neededSize = vsnprintf(NULL, 0, format, va);
     if (neededSize <= 0)

--- a/src/consolelogger.c
+++ b/src/consolelogger.c
@@ -14,7 +14,8 @@
 static char* vprintf_alloc(const char* format, va_list va)
 {
 #pragma warning(push)
-#pragma warning(disable:26451 6386)
+#pragma warning(disable:26451)
+#pragma warning(disable:6386)
     char* result;
     int neededSize = vsnprintf(NULL, 0, format, va);
     if (neededSize < 0)


### PR DESCRIPTION
This PR fixes SDL native rules static analysis error

external\azure-c-shared-utility\src\consolelogger.c(33,62): error 6386:  : Buffer overrun while writing to 'result':  the writable size is '(unsigned int)neededSize+(unsigned int)1' bytes, but '1' bytes might be written.
