### PR TITLE
Add the ability to retrieve the detailed inner error code for HTTP failures

### DIFF
--- a/adapters/tlsio_schannel.c
+++ b/adapters/tlsio_schannel.c
@@ -941,6 +941,8 @@ static void on_underlying_io_error(void* context)
 {
     TLS_IO_INSTANCE* tls_io_instance = (TLS_IO_INSTANCE*)context;
 
+    int originalErrorCode = (int)tls_io_instance->tlsio_state;
+
     switch (tls_io_instance->tlsio_state)
     {
     default:
@@ -954,7 +956,7 @@ static void on_underlying_io_error(void* context)
         tls_io_instance->tlsio_state = TLSIO_STATE_ERROR;
         if (tls_io_instance->on_io_open_complete != NULL)
         {
-            IO_OPEN_RESULT_DETAILED error_result = { IO_OPEN_ERROR, __FAILURE__ };
+            IO_OPEN_RESULT_DETAILED error_result = { IO_OPEN_ERROR, originalErrorCode };
             tls_io_instance->on_io_open_complete(tls_io_instance->on_io_open_complete_context, error_result);
         }
         break;


### PR DESCRIPTION
This adds the ability to retrieve the inner platform specific error code for HTTP failures. This enables richer error reporting more inline with what the web socket code already provides.

To avoid changing public API signatures (which can be a breaking change), I've added a separate HTTPAPI_GetLastError method to retrieve this code. This can be called after a failure is returned to get the inner code. For now I've not included this in the public header files