### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 *.jar
 *.aps
 /res
+/testtools/SerialPort/SerialPort/obj/**/*


### PR DESCRIPTION
When I build carbon using VS from scratch, I get this obj folder showing up under the "Changes not staged for commit" in git status (even though this folder is excluded in Carbon's root .gitignore). In an attempt to fix this, I excluding it also from this .gitignore.