### PR TITLE
First cut of supporting OpenSSL 3.0 compiling

### DIFF
--- a/adapters/shim_openssl.c
+++ b/adapters/shim_openssl.c
@@ -21,7 +21,11 @@ FOR_ALL_OPENSSL_FUNCTIONS
 
 int load_libssl()
 {
-#if USE_OPENSSL_1_1_0_OR_UP
+#if USE_OPENSSL_3_0_X
+    static char *soNames[] = {
+        "libssl.so.3"
+    };
+#elif USE_OPENSSL_1_1_0_OR_UP
     static char *soNames[] = {
         "libssl.so.1.1"
     };
@@ -63,7 +67,14 @@ int load_libssl()
 
     // Discover the version and check it.
 
-#if USE_OPENSSL_1_1_0_OR_UP
+#if USE_OPENSSL_3_0_X
+    const int minVersion = 0x30000000L;
+    const int maxVersion = 0x30100000L;  // 3.1.0 - I don't know if we are compatible for all 3.x yet
+    REQUIRED_FUNCTION(OpenSSL_version_num);
+    if (OpenSSL_version_num_ptr) {
+        runtimeVersion = OpenSSL_version_num();
+    }
+#elif USE_OPENSSL_1_1_0_OR_UP
     const int minVersion = 0x10100000L;
     const int maxVersion = 0x20000000L;
     REQUIRED_FUNCTION(OpenSSL_version_num);

--- a/adapters/shim_openssl.h
+++ b/adapters/shim_openssl.h
@@ -289,8 +289,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_get0_param SSL_get0_param_ptr
 
 #if USE_OPENSSL_3_0_X
-// OpenSSL 3.0 compatibility macrros deal with some changes but we need to
-// deal with the newer funcitons needed and not include those that no longer
+// OpenSSL 3.0 compatibility macros deal with some changes but we need to
+// deal with the newer functions needed and not include those that no longer
 // exist in OpenSSL 3
 #define EVP_PKEY_get_id EVP_PKEY_get_id_ptr
 #define OSSL_HTTP_parse_url OSSL_HTTP_parse_url_ptr

--- a/adapters/x509_openssl.c
+++ b/adapters/x509_openssl.c
@@ -63,7 +63,7 @@ static int load_certificate_chain(SSL_CTX* ssl_ctx, const char* certificate)
                 // certificates.
 
                 /* Codes_SRS_X509_OPENSSL_07_006: [ If successful x509_openssl_add_ecc_credentials shall to import each certificate in the cert chain. ] */
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
+#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)) || (OPENSSL_VERSION_NUMBER >= 0x30000000L)
                 SSL_CTX_clear_extra_chain_certs(ssl_ctx);
 #else
                 if (ssl_ctx->extra_certs != NULL)
@@ -254,7 +254,7 @@ int x509_openssl_add_certificates(SSL_CTX* ssl_ctx, const char* certificates)
         else
         {
             /*Codes_SRS_X509_OPENSSL_02_012: [ x509_openssl_add_certificates shall get the memory BIO method function by calling BIO_s_mem. ]*/
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
+#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)) || (OPENSSL_VERSION_NUMBER >= 0x30000000L)
             const BIO_METHOD* bio_method;
 #else
             BIO_METHOD* bio_method;


### PR DESCRIPTION
Compiling on Ubuntu 22.04, which is OpenSSL 3.0 based, this now compiles and runs some basic unit tests, including talking to the server.

The changes were made such that older builds on OpenSSL 1.1.x still work as before.

Some functions no longer exist in OpenSSL 3 and some new functions are in OpenSSL 3 and not in 1.  Thus neither is a superset of the other.

This is currently a compile-time behavior and not a run-time behavior as we used compile time compatibility shims and macros.

Doing this at run time will be more complex due to the current structure of the code.

The containers and scripts I committed into ci/docker-dev for Carbon take care of making it easy to test build both variants on the same machine.  (Or more variants if we need to - I just built the 20.04 and 22.04 variants for OpenSSL 1.1 and OpenSSL 3.0 build and test processes but adding RedHat or CentOS or Mariner or Debian would not be a significant challenge.)  All of that is not part of this PR but makes building and testing the variant versions much easier.

PS - I am sure that now that it is working we could write some code to make it work in both but it is somewhat complicated by the fact that it would take specific shims for a number of functions and parameters that would need to dynamically determine the code paths to use for each version.  It is non-trivial but it does not seem to be impossible. (Tricky due to mapping of methods across different versions of header files - unclear how to do that yet)