### PR TITLE
Fix memory leak when there are duplicate CRL's in the file system cache.

### DIFF
--- a/adapters/platform_linux.c
+++ b/adapters/platform_linux.c
@@ -64,6 +64,7 @@ STRING_HANDLE platform_get_platform_info(void)
 
 void platform_deinit(void)
 {
+    LogInfo("platform_deinit called.");
 #ifdef USE_OPENSSL
     tlsio_openssl_deinit();
 #endif

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -1156,6 +1156,7 @@ static int save_cert_crl_memory(X509 *cert, X509_CRL *crlp)
         crlp->references++;
 #endif
     }
+
     LogInfo("saving crl to memory cache");
 
     // update existing
@@ -1177,7 +1178,6 @@ static int save_cert_crl_memory(X509 *cert, X509_CRL *crlp)
         if (0 == X509_NAME_cmp(issuer_crl, issuer_cert))
         {
             LogInfo("updating existing crl in memory cache");
-//            void *leak = (void *)malloc(sizeof(char));
 
             X509_CRL_free(crl);
 


### PR DESCRIPTION
The key change is the break on line 1501, that fixes the leak of CRL's when there are multiple ones on disk that match.

Other changes:
Added more logging to see that the platform is being de-initialized.
Added code to free the CRL cache on de-init.
Optimized CRL save to disk to prevent duplicate CRL's in the first place.