### PR TITLE
Add additional logging when Certificate validation fails

### DIFF
--- a/adapters/shim_openssl.h
+++ b/adapters/shim_openssl.h
@@ -149,6 +149,7 @@
     REQUIRED_FUNCTION(SSL_do_handshake) \
     REQUIRED_FUNCTION(SSL_free) \
     REQUIRED_FUNCTION(SSL_get_error) \
+    REQUIRED_FUNCTION(SSL_get_verify_result) \
     REQUIRED_FUNCTION_1_0_2(SSL_library_init) \
     REQUIRED_FUNCTION_1_0_2(SSL_load_error_strings) \
     REQUIRED_FUNCTION(SSL_new) \
@@ -208,6 +209,7 @@
     REQUIRED_FUNCTION(SSL_set_verify) \
     REQUIRED_FUNCTION(X509_STORE_set_verify_cb) \
     REQUIRED_FUNCTION(X509_STORE_CTX_get_error) \
+    REQUIRED_FUNCTION(X509_verify_cert_error_string) \
     REQUIRED_FUNCTION(SSL_get0_param)
 
 #if USE_OPENSSL_1_1_0_OR_UP
@@ -287,6 +289,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_do_handshake SSL_do_handshake_ptr
 #define SSL_free SSL_free_ptr
 #define SSL_get_error SSL_get_error_ptr
+#define SSL_get_verify_result SSL_get_verify_result_ptr
 #define SSL_new SSL_new_ptr
 #define SSL_read SSL_read_ptr
 #define SSL_set_bio SSL_set_bio_ptr
@@ -319,6 +322,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_set_verify SSL_set_verify_ptr
 #define X509_STORE_set_verify_cb X509_STORE_set_verify_cb_ptr
 #define X509_STORE_CTX_get_error X509_STORE_CTX_get_error_ptr
+#define X509_verify_cert_error_string X509_verify_cert_error_string_ptr
 #define SSL_get0_param SSL_get0_param_ptr
 
 #if USE_OPENSSL_3_0_X

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -689,11 +689,17 @@ static void send_handshake_bytes(TLS_IO_INSTANCE* tls_io_instance)
         {
             if (ssl_err == SSL_ERROR_SSL)
             {
-                LogError("TLS handshake failed with SSL error: %s", ERR_error_string(ERR_get_error(), NULL));
+                long verify_result = SSL_get_verify_result(tls_io_instance->ssl);
+                LogError("TLS handshake failed for %s with SSL error: %s (verify result: %ld - %s)",
+                    hostname,
+                    ERR_error_string(ERR_get_error(), NULL),
+                    verify_result,
+                    X509_verify_cert_error_string(verify_result));
+                log_ERR_get_error("Additional OpenSSL error queue entries");
             }
             else
             {
-                LogError("TLS handshake failed: ssl_err=%d", ssl_err);
+                LogError("TLS handshake failed for %s: ssl_err=%d", hostname, ssl_err);
             }
             tls_io_instance->tlsio_state = TLSIO_STATE_HANDSHAKE_FAILED;
         }


### PR DESCRIPTION
New messages will have:

[286656]: 1090ms SPX_TRACE_ERROR: AZ_LOG_ERROR:  tlsio_openssl.c:693 TLS handshake failed for localhost with SSL error: error:0A000086:SSL routines::certificate verify failed (verify result: 10 - certificate has expired)

[286656]: 2109ms SPX_TRACE_ERROR: AZ_LOG_ERROR:  tlsio_openssl.c:693 TLS handshake failed for localhost with SSL error: error:0A000086:SSL routines::certificate verify failed (verify result: 62 - hostname mismatch)

 