### PR TITLE
Update CMake minimum required version to 3.12 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 # Honor visibility properties for all target types
 cmake_policy(SET CMP0063 NEW)

--- a/build_all/mbed/CMakeLists.txt
+++ b/build_all/mbed/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 set(shared_util_base_path ../..)
 set(mbed_project_base "azure_c_shared_utility" CACHE STRING "The item being built")

--- a/configs/azure_iot_external_pal_unit_test_setup.cmake
+++ b/configs/azure_iot_external_pal_unit_test_setup.cmake
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 # quiet the CMake warning about unused command line args "use_wsio". This is from the c-utility CMake command.
 set(ignore_me ${use_wsio})

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 function(add_sample_directory whatIsBuilding)
     add_subdirectory(${whatIsBuilding})

--- a/samples/socketio_connect/mbed/CMakeLists.txt
+++ b/samples/socketio_connect/mbed/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 set(shared_util_base_path ../../..)
 set(mbed_project_base "socketio_connect" CACHE STRING "The item being built")

--- a/samples/tlsio_connect/mbed/CMakeLists.txt
+++ b/samples/tlsio_connect/mbed/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 set(shared_util_base_path ../../..)
 set(mbed_project_base "tlsio_connect" CACHE STRING "The item being built")

--- a/tests/agenttime_ut/CMakeLists.txt
+++ b/tests/agenttime_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for agenttime_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 

--- a/tests/base32_ut/CMakeLists.txt
+++ b/tests/base32_ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName base32_ut)

--- a/tests/base64_ut/CMakeLists.txt
+++ b/tests/base64_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for base64_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName base64_ut)

--- a/tests/buffer_ut/CMakeLists.txt
+++ b/tests/buffer_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for buffer_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName buffer_ut)

--- a/tests/condition_ut/CMakeLists.txt
+++ b/tests/condition_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for condition_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName condition_ut)

--- a/tests/connectionstringparser_ut/CMakeLists.txt
+++ b/tests/connectionstringparser_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for connectionstringparser_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC99()
 set(theseTestsName connectionstringparser_ut)

--- a/tests/constbuffer_ut/CMakeLists.txt
+++ b/tests/constbuffer_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for buffer_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName constbuffer_ut)

--- a/tests/constmap_ut/CMakeLists.txt
+++ b/tests/constmap_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for map_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName constmap_ut)

--- a/tests/crtabstractions_ut/CMakeLists.txt
+++ b/tests/crtabstractions_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for crt_abstractions_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 

--- a/tests/dns_async_ut/CMakeLists.txt
+++ b/tests/dns_async_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for <myTestName>_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName dns_async_ut)

--- a/tests/doublylinkedlist_ut/CMakeLists.txt
+++ b/tests/doublylinkedlist_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for doublylinkedlist_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 

--- a/tests/gballoc_ut/CMakeLists.txt
+++ b/tests/gballoc_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for gballoc_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 set(theseTestsName gballoc_ut)
 
 set(${theseTestsName}_test_files

--- a/tests/gballoc_without_init_ut/CMakeLists.txt
+++ b/tests/gballoc_without_init_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for gballoc_without_init_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 set(theseTestsName gballoc_without_init_ut)
 

--- a/tests/hmacsha256_ut/CMakeLists.txt
+++ b/tests/hmacsha256_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for hmacsha256_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName hmacsha256_ut)

--- a/tests/http_proxy_io_ut/CMakeLists.txt
+++ b/tests/http_proxy_io_ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName http_proxy_io_ut)

--- a/tests/httpapicompact_ut/CMakeLists.txt
+++ b/tests/httpapicompact_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for httpapi_compact_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 if(NOT ${use_http})
 	message(FATAL_ERROR "httpapi_compact_ut being generated without HTTP support")

--- a/tests/httpapiex_ut/CMakeLists.txt
+++ b/tests/httpapiex_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for httpapiex_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 if(NOT ${use_http})
 	message(FATAL_ERROR "httpapiex_ut being generated without HTTP support")

--- a/tests/httpapiexsas_ut/CMakeLists.txt
+++ b/tests/httpapiexsas_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for httpapiexsas_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 if(NOT ${use_http})
 	message(FATAL_ERROR "httpapiexsas_ut being generated without HTTP support")

--- a/tests/httpheaders_ut/CMakeLists.txt
+++ b/tests/httpheaders_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for httpheaders_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 if(NOT ${use_http})
 	message(FATAL_ERROR "httpheaders_ut being generated without HTTP support")

--- a/tests/lock_ut/CMakeLists.txt
+++ b/tests/lock_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for lock_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName lock_ut)

--- a/tests/map_ut/CMakeLists.txt
+++ b/tests/map_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for map_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName map_ut)

--- a/tests/optionhandler_ut/CMakeLists.txt
+++ b/tests/optionhandler_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for optionhandler_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName optionhandler_ut)

--- a/tests/platform_win32_ut/CMakeLists.txt
+++ b/tests/platform_win32_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for urlencode_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 if(MSVC)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /IGNORE:4217")

--- a/tests/refcount_ut/CMakeLists.txt
+++ b/tests/refcount_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for map_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName refcount_ut)

--- a/tests/sastoken_ut/CMakeLists.txt
+++ b/tests/sastoken_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for sastoken_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName sastoken_ut)

--- a/tests/singlylinkedlist_ut/CMakeLists.txt
+++ b/tests/singlylinkedlist_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for lock_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName singlylinkedlist_ut)

--- a/tests/socket_async_ut/CMakeLists.txt
+++ b/tests/socket_async_ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName socket_async_ut)

--- a/tests/socketio_berkeley_ut/CMakeLists.txt
+++ b/tests/socketio_berkeley_ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 if(MSVC)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /IGNORE:4217")

--- a/tests/socketio_win32_ut/CMakeLists.txt
+++ b/tests/socketio_win32_ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 if(MSVC)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /IGNORE:4217")

--- a/tests/string_tokenizer_ut/CMakeLists.txt
+++ b/tests/string_tokenizer_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for $string_tokenizer_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName string_tokenizer_ut)

--- a/tests/strings_ut/CMakeLists.txt
+++ b/tests/strings_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for strings_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName strings_ut)

--- a/tests/template_ut/CMakeLists.txt
+++ b/tests/template_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for <myTestName>_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName template_ut)

--- a/tests/tickcounter_freertos_ut/CMakeLists.txt
+++ b/tests/tickcounter_freertos_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for urlencode_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName tickcounter_freertos_ut)

--- a/tests/tickcounter_ut/CMakeLists.txt
+++ b/tests/tickcounter_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for urlencode_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName tickcounter_ut)

--- a/tests/tlsio_cyclonessl_socket_bsd_ut/CMakeLists.txt
+++ b/tests/tlsio_cyclonessl_socket_bsd_ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName tlsio_cyclonessl_socket_bsd_ut)

--- a/tests/tlsio_cyclonessl_ut/CMakeLists.txt
+++ b/tests/tlsio_cyclonessl_ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName tlsio_cyclonessl_ut)

--- a/tests/tlsio_options_ut/CMakeLists.txt
+++ b/tests/tlsio_options_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for urlencode_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName tlsio_options_ut)

--- a/tests/tlsio_wolfssl_ut/CMakeLists.txt
+++ b/tests/tlsio_wolfssl_ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName tlsio_wolfssl_ut)

--- a/tests/uniqueid_ut/CMakeLists.txt
+++ b/tests/uniqueid_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for buffer_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName uniqueid_ut)

--- a/tests/urlencode_ut/CMakeLists.txt
+++ b/tests/urlencode_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for urlencode_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName urlencode_ut)

--- a/tests/utf8_checker_ut/CMakeLists.txt
+++ b/tests/utf8_checker_ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC99()
 set(theseTestsName utf8_checker_ut)

--- a/tests/uuid_ut/CMakeLists.txt
+++ b/tests/uuid_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for uuid_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName uuid_ut)

--- a/tests/uws_client_ut/CMakeLists.txt
+++ b/tests/uws_client_ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC99()
 set(theseTestsName uws_client_ut)

--- a/tests/uws_frame_encoder_ut/CMakeLists.txt
+++ b/tests/uws_frame_encoder_ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC99()
 set(theseTestsName uws_frame_encoder_ut)

--- a/tests/vector_ut/CMakeLists.txt
+++ b/tests/vector_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for vector_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName vector_ut)

--- a/tests/wsio_ut/CMakeLists.txt
+++ b/tests/wsio_ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC99()
 set(theseTestsName wsio_ut)

--- a/tests/x509_openssl_ut/CMakeLists.txt
+++ b/tests/x509_openssl_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for vector_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName x509_openssl_ut)

--- a/tests/x509_schannel_ut/CMakeLists.txt
+++ b/tests/x509_schannel_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for vector_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName x509_schannel_ut)

--- a/tests/xio_ut/CMakeLists.txt
+++ b/tests/xio_ut/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists.txt for lock_ut
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC11()
 set(theseTestsName xio_ut)

--- a/testtools/micromock/CMakeLists.txt
+++ b/testtools/micromock/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists for micromock
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 set(micromock_cpp_files
 ./src/micromockcharstararenullterminatedstrings.cpp

--- a/testtools/micromock/unittests/CMakeLists.txt
+++ b/testtools/micromock/unittests/CMakeLists.txt
@@ -2,6 +2,6 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists for micromock unittests folder, it is empty
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 add_subdirectory(micromocktest)

--- a/testtools/micromock/unittests/micromocktest/CMakeLists.txt
+++ b/testtools/micromock/unittests/micromocktest/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists for micromock unittests
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 set(theseTestsName micromock_unittests)
 

--- a/testtools/sal/CMakeLists.txt
+++ b/testtools/sal/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #this is CMakeLists for sal. It only defines a global include 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 compileAsC99()
 

--- a/tools/mbed_build_scripts/mbedbldtemplate.txt
+++ b/tools/mbed_build_scripts/mbedbldtemplate.txt
@@ -7,7 +7,7 @@
 ### To use add -Drelease_the_project:bool=ON
 option(release_the_project "Used to just push the project and adjust the appending of _bld" off)
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 set(HG_COMMIT_MSG "Automatic Build Commit" CACHE STRING "Passed to the mercurial commit")
 
 project(${mbed_project_base})


### PR DESCRIPTION
…modern CMake/ADO agents

azure-c-shared-utility used cmake_minimum_required(VERSION 2.8.11) across 60 CMakeLists/.cmake files. Modern CMake (3.30+) drops compatibility with versions <3.5, causing configure failures on ADO build agents and requiring the -DCMAKE_POLICY_VERSION_MINIMUM=3.5 workaround. Bumped all to 3.12.